### PR TITLE
COR packet format updates

### DIFF
--- a/src/formats/cor.hpp
+++ b/src/formats/cor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, The Bifrost Authors. All rights reserved.
+ * Copyright (c) 2019-2021, The Bifrost Authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,6 +62,7 @@ public:
 	    const cor_hdr_type* pkt_hdr  = (cor_hdr_type*)pkt_ptr;
 	    const uint8_t*      pkt_pld  = pkt_ptr  + sizeof(cor_hdr_type);
 	    int                 pld_size = pkt_size - sizeof(cor_hdr_type);
+	    uint8_t             chan_decim = (be32toh(pkt_hdr->frame_count_word) >> 16) & 0xFF;
 	    uint8_t             nserver = (be32toh(pkt_hdr->frame_count_word) >> 8) & 0xFF;
 	    uint8_t             server = be32toh(pkt_hdr->frame_count_word) & 0xFF;
 	    uint16_t            nchan_pkt = (pld_size/(8*4));
@@ -76,7 +77,7 @@ public:
 	    pkt->src          = (stand0*(2*(nstand-1)+1-stand0)/2 + stand1 + 1 - _src0)*nserver \
 	                        + (server - 1);
 	    pkt->chan0        = be16toh(pkt_hdr->first_chan) \
-	                        - nchan_pkt * (server - 1);
+	                        - nchan_decim*nchan_pkt * (server - 1);
 	    pkt->nchan        = nchan_pkt;
 	    pkt->tuning       = (nserver << 8) | (server - 1);  // Stores the number of servers and 
                                                             // the server that sent this packet

--- a/src/formats/cor.hpp
+++ b/src/formats/cor.hpp
@@ -62,7 +62,7 @@ public:
 	    const cor_hdr_type* pkt_hdr  = (cor_hdr_type*)pkt_ptr;
 	    const uint8_t*      pkt_pld  = pkt_ptr  + sizeof(cor_hdr_type);
 	    int                 pld_size = pkt_size - sizeof(cor_hdr_type);
-	    uint8_t             chan_decim = (be32toh(pkt_hdr->frame_count_word) >> 16) & 0xFF;
+	    uint8_t             nchan_decim = (be32toh(pkt_hdr->frame_count_word) >> 16) & 0xFF;
 	    uint8_t             nserver = (be32toh(pkt_hdr->frame_count_word) >> 8) & 0xFF;
 	    uint8_t             server = be32toh(pkt_hdr->frame_count_word) & 0xFF;
 	    uint16_t            nchan_pkt = (pld_size/(8*4));

--- a/src/formats/cor.hpp
+++ b/src/formats/cor.hpp
@@ -72,7 +72,7 @@ public:
 	    pkt->sync         = pkt_hdr->sync_word;
 	    pkt->time_tag     = be64toh(pkt_hdr->time_tag);
 	    pkt->decimation   = be32toh(pkt_hdr->navg);
-	    pkt->seq          = pkt->time_tag / 196000000 / (pkt->decimation / 100);
+	    pkt->seq          = pkt->time_tag / pkt->decimation;
 	    pkt->nsrc         = _nsrc;
 	    pkt->src          = (stand0*(2*(nstand-1)+1-stand0)/2 + stand1 + 1 - _src0)*nserver \
 	                        + (server - 1);

--- a/src/ib_verbs.hpp
+++ b/src/ib_verbs.hpp
@@ -647,7 +647,7 @@ class Verbs {
                     recv_head = &(_verbs.pkt_buf[wr_id]);
                     recv_tail = &recv_head->wr;
                 } else {
-                    recv_tail = &(_verbs.pkt_buf[wr_id].wr);
+                    recv_tail->next = &(_verbs.pkt_buf[wr_id].wr);
                     recv_tail = recv_tail->next;
                 }
             } // for each work completion


### PR DESCRIPTION
This PR fixes a couple of problems with the COR packet format used at OVRO-LWA with regards to how the sequence number is determined from the time tag and how the first channel in "fast mode" packets are interpreted.